### PR TITLE
fix: compile updater on release platforms

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -40,3 +40,31 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check PyYAML==6.0.3
           python scripts/validate-workflows.py
+
+  platform-compile:
+    name: ${{ matrix.name }} platform compile
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            os: ubuntu-22.04
+          - name: macOS
+            os: macos-14
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - run: rustup show
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config cmake clang libssl-dev \
+            libfontconfig1-dev libfreetype6-dev libx11-dev libxcb1-dev libxrandr-dev \
+            libxi-dev libxcursor-dev libxdamage-dev libxfixes-dev libxrender-dev \
+            libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev libgl1-mesa-dev \
+            libvulkan-dev
+      - name: Compile platform-specific binaries and tests
+        run: cargo check --workspace --all-targets --all-features --locked

--- a/crates/gmark-config/tests/dirs.rs
+++ b/crates/gmark-config/tests/dirs.rs
@@ -9,7 +9,9 @@ use gmark_config::{
     read_recent_files_with_dirs,
 };
 #[cfg(unix)]
-use gmark_config::{WorkspaceSession, WorkspaceSessionTab, record_recent_file_with_dirs};
+use gmark_config::{
+    WorkspaceSession, WorkspaceSessionPane, WorkspaceSessionTab, record_recent_file_with_dirs,
+};
 use tempfile::TempDir;
 #[cfg(unix)]
 use uuid::Uuid;
@@ -172,12 +174,14 @@ fn sensitive_state_files_are_created_with_mode_0600() -> Result<()> {
     assert_eq!(installation_mode, 0o600);
 
     let store = WorkspaceSessionStore::new(dirs.clone());
-    store.upsert(&WorkspaceSession::new(
-        Uuid::new_v4(),
-        vec![WorkspaceSessionTab::new("session.md".into(), false)],
-        0,
-        None,
-    ))?;
+    let mut session = WorkspaceSession::single_pane(Uuid::new_v4(), None);
+    let pane_id = session.focused_pane;
+    let tab = WorkspaceSessionTab::new("session.md".into(), false);
+    let tab_id = tab.id;
+    session
+        .panes
+        .insert(pane_id, WorkspaceSessionPane::new(vec![tab], Some(tab_id)));
+    store.upsert(&session)?;
     let session_mode = fs::metadata(dirs.workspace_session_file())?
         .permissions()
         .mode()

--- a/scripts/validate-workflows.py
+++ b/scripts/validate-workflows.py
@@ -218,6 +218,31 @@ def validate_release_contract(
         fail(path, "release job must explicitly allow skipped non-release gates")
 
 
+def validate_quality_contract(path: Path, jobs: dict[str, object]) -> None:
+    """锁定非 Windows 平台编译门禁，避免 cfg 专属代码直到正式发布才暴露类型错误。"""
+
+    platform_compile = jobs.get("platform-compile")
+    if not isinstance(platform_compile, dict):
+        fail(path, "quality workflow requires Linux and macOS platform compile gates")
+    strategy = platform_compile.get("strategy")
+    matrix = strategy.get("matrix") if isinstance(strategy, dict) else None
+    include = matrix.get("include") if isinstance(matrix, dict) else None
+    if not isinstance(include, list):
+        fail(path, "platform compile gate requires an explicit runner matrix")
+    runners = {
+        entry.get("os")
+        for entry in include
+        if isinstance(entry, dict) and isinstance(entry.get("os"), str)
+    }
+    if not any(runner.startswith("ubuntu-") for runner in runners) or not any(
+        runner.startswith("macos-") for runner in runners
+    ):
+        fail(path, "platform compile gate must cover Linux and macOS runners")
+    scripts = joined_run_scripts(platform_compile.get("steps"))
+    if "cargo check --workspace --all-targets --all-features --locked" not in scripts:
+        fail(path, "platform compile gate must type-check every target with all features")
+
+
 def main() -> None:
     workflows = sorted((ROOT / ".github" / "workflows").glob("*.y*ml"))
     if not workflows:
@@ -241,6 +266,8 @@ def main() -> None:
                 fail(path, f"job {job_name} requires steps or reusable-workflow uses")
         if path.name == "build-release.yml":
             validate_release_contract(path, document, jobs)
+        if path.name == "quality.yml":
+            validate_quality_contract(path, jobs)
     print(f"parsed and validated {len(workflows)} GitHub Actions workflows")
 
 

--- a/src/bin/gmark_update_helper/linux.rs
+++ b/src/bin/gmark_update_helper/linux.rs
@@ -52,13 +52,11 @@ pub fn install(
         copy_verified_artifact(artifact, &temporary, current_mode, plan.artifact_size)
     {
         remove_owned_temp(&temporary);
-        return Err(error);
+        return Err(error.into());
     }
     if let Err(error) = fs::rename(&temporary, target) {
         remove_owned_temp(&temporary);
-        return Err(format!(
-            "failed to atomically install new AppImage: {error}"
-        ));
+        return Err(format!("failed to atomically install new AppImage: {error}").into());
     }
     sync_directory(parent).map_err(PlatformInstallFailure::committed_or_unknown)
 }

--- a/src/bin/gmark_update_helper/macos.rs
+++ b/src/bin/gmark_update_helper/macos.rs
@@ -74,7 +74,8 @@ pub fn install(
     if !same_volume(staging.path(), parent)? {
         return Err(
             "macOS update staging directory must be on the same volume as the installed application"
-                .to_owned(),
+                .to_owned()
+                .into(),
         );
     }
     artifact
@@ -93,9 +94,9 @@ pub fn install(
                 .map_err(PlatformInstallFailure::committed_or_unknown)?;
         }
         Err(error) => {
-            return Err(format!(
-                "failed to atomically exchange macOS application bundle: {error}"
-            ));
+            return Err(
+                format!("failed to atomically exchange macOS application bundle: {error}").into(),
+            );
         }
     }
     // A failed directory sync is reported after the exchange and therefore


### PR DESCRIPTION
## 根因

正式 v0.2.1 发布的 Linux Release 编译暴露两处 cfg(target_os = "linux") 专属返回类型错误：String 未转换为 PlatformInstallFailure。Windows PR 门禁未编译 Linux 模块，因此没有提前发现。

## 修复

- 将 Linux AppImage 提交前失败显式转换为 PlatformInstallFailure
- Quality 新增 Linux/macOS 原生全 workspace、全 target、全 feature 编译矩阵
- workflow validator 锁定该跨平台门禁，防止未来被无意删除

## 验证

- cargo fmt --all -- --check
- cargo check --locked --all-features --bins
- cargo run --locked -p xtask -- quality
- python -B scripts/validate-workflows.py
- actionlint v1.7.10
- git diff --check

失败的发布运行未创建 v0.2.1 标签或 Release；本 PR 通过并合并后可安全重新触发同一版本。
